### PR TITLE
Update page titles to include "Elliott Schmechel" for consistency acr…

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,5 @@ All commands are run from the root of the project, from a terminal:
 | `npm run preview`         | Preview your build locally, before deploying
 
 ## TODO LIST
-Replace `public/images/og-image.png`
-^Default image for sharing on social media websites
+might need to replace og-image
 `src/islands/MobileMenu.tsx` the js for scroll-locking when the menu is open could potentionally be replaced with pure react using react-aria/UsePreventScroll package

--- a/src/layouts/ProjectLayout.astro
+++ b/src/layouts/ProjectLayout.astro
@@ -38,7 +38,7 @@ if (category === 'Website' && externalLink) {
 }
 ---
 
-<BaseLayout title={pageTitle} description={pageDescription}>
+<BaseLayout title={`${title} | Elliott Schmechel`} description={pageDescription}>
   <article class="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 py-16 lg:py-24">
     <!-- Back Navigation -->
     <nav class="mb-8">

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -4,12 +4,10 @@ import BaseLayout from '../layouts/BaseLayout.astro';
 import { personalData } from '../data/personalData';
 import Socials from '../data/socialData';
 import { getSocialIcon } from '../utils/socialIcons';
-
-const pageTitle = `About | ${personalData.meta.siteName}`;
 const pageDescription = `Learn more about ${personalData.name}, ${personalData.title} with 4 years of experience.`;
 ---
 
-<BaseLayout title={pageTitle} description={pageDescription}>
+<BaseLayout title={`About Me | Elliott Schmechel`} description={pageDescription}>
   <div class="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 py-16 lg:py-24">
     <!-- Header -->
     <div class="text-center mb-16">

--- a/src/pages/blog/index.astro
+++ b/src/pages/blog/index.astro
@@ -6,7 +6,7 @@ import { personalData } from '../../data/personalData';
 import Socials from '../../data/socialData';
 import { getSocialIcon } from '../../utils/socialIcons';
 
-const pageTitle = `Blog | ${personalData.meta.siteName}`;
+const pageTitle = `${personalData.meta.siteName}`;
 const pageDescription = 'Insights about game development, programming, and technology from Elliott Schmechel.';
 
 // Get all blog posts and sort by pinned status first, then by publication date (newest first)
@@ -40,7 +40,7 @@ const getReadingTime = (content: string) => {
 };
 ---
 
-<BaseLayout title={pageTitle} description={pageDescription}>
+<BaseLayout title={`${pageTitle} | Elliott Schmechel`} description={pageDescription}>
   <div class="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 py-16 lg:py-24">
     <!-- Header -->
     <div class="text-center mb-16">

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -5,11 +5,10 @@ import Hero from '../components/Hero.astro';
 import TechStack from '../islands/TechStack.tsx';
 import MosaicGrid from '../components/MosaicGrid.astro';
 import { personalData } from '../data/personalData.ts';
-const pageTitle = `${personalData.meta.siteName} | ${personalData.title}`;
 const pageDescription = personalData.meta.description;
 ---
 
-<BaseLayout title={pageTitle} description={pageDescription}>
+<BaseLayout title={`Home | Elliott Schmechel`} description={pageDescription}>
   <Hero />
   <TechStack client:load />
   <MosaicGrid />

--- a/src/pages/projects/index.astro
+++ b/src/pages/projects/index.astro
@@ -58,7 +58,7 @@ const normalizedProjects = projectsWithLiveStatus;
 const featuredProjects = projectsWithLiveStatus.filter(project => project.isFeatured);
 ---
 
-<BaseLayout title={pageTitle} description={pageDescription}>
+<BaseLayout title={`${pageTitle} | Elliott Schmechel`} description={pageDescription}>
   <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-16 lg:py-24">
     <!-- Header -->
     <div class="text-center mb-16">


### PR DESCRIPTION

This pull request standardizes page titles across the site to consistently include "Elliott Schmechel" and improves clarity in the README's TODO section. The changes primarily update the `title` prop in various layout components and adjust the README for better maintainability.

**Page title standardization:**

* Updated the `title` prop in `BaseLayout` for the About, Home, Blog index, Projects index, and Project detail pages to consistently append or prepend "Elliott Schmechel" for improved branding and SEO. (`src/pages/about.astro`, `src/pages/index.astro`, `src/pages/blog/index.astro`, `src/pages/projects/index.astro`, `src/layouts/ProjectLayout.astro`) [[1]](diffhunk://#diff-cb33463363c150558e340277672bb5c583640ddb38012f53a33ed69125d92038L7-R10) [[2]](diffhunk://#diff-95d291e9ce4c8739cc7e65ff7bf0838dd5294cf39ab787ba51a42d08fb2df663L8-R11) [[3]](diffhunk://#diff-a64eb99d116304a8bedfb2764ef2708e4ede269e512028d3eca22ba03651153aL9-R9) [[4]](diffhunk://#diff-a64eb99d116304a8bedfb2764ef2708e4ede269e512028d3eca22ba03651153aL43-R43) [[5]](diffhunk://#diff-956dfcbe6a61ed56c0875b14836f625ca4fe8492b590ba31f11b0904651f916fL61-R61) [[6]](diffhunk://#diff-e0c59fb437147cf858ecb16131b85d0043e007139f0c81331cf606066a4c659dL41-R41)

**Documentation updates:**

* Clarified the README's TODO section by rewording the note about replacing the default social sharing image and suggesting a potential improvement to scroll-locking in `src/islands/MobileMenu.tsx`. (`README.md`)